### PR TITLE
Support .env.example and etc

### DIFF
--- a/ftdetect/env.vim
+++ b/ftdetect/env.vim
@@ -1,1 +1,2 @@
 autocmd BufRead,BufNewFile *.env set ft=env
+autocmd BufRead,BufNewFile .env.* set ft=env


### PR DESCRIPTION
Match `.env.example`, `.env.production`, `.env.production.local`, `.env.staging`, `.env.staging.local`, `.env.testing` and etc
Patch from @ulcuber